### PR TITLE
fix: apiでネイティブfetchを代入する際に無名関数でラップするように

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,7 @@ export class APIClient {
 	}) {
 		this.origin = opts.origin;
 		this.credential = opts.credential;
-		this.fetch = opts.fetch || fetch;
+		this.fetch = opts.fetch || ((...args) => fetch(...args));
 	}
 
 	public request<E extends keyof Endpoints, P extends Endpoints[E]['req']>(


### PR DESCRIPTION
# What
apiにブラウザネイティブのfetchを格納する際、そのまま代入せず無名関数でラップしたものを代入するように

# Why
特にChromiumでは、ネイティブ関数をそのまま変数に代入しようとするとIllegal invocationエラーが発生する。

See https://github.com/misskey-dev/misskey/pull/7667#issuecomment-923162458
