### PR TITLE
Add missing main stream types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- add missing main stream types
+
 # 0.0.10
 - add consts
 

--- a/etc/misskey-js.api.md
+++ b/etc/misskey-js.api.md
@@ -2047,6 +2047,9 @@ type FetchLike = (input: string, init?: {
 }>;
 
 // @public (undocumented)
+export const ffVisibility: readonly ["public", "followers", "private"];
+
+// @public (undocumented)
 type Following = {
     id: ID;
     createdAt: DateString;
@@ -2178,6 +2181,9 @@ type MessagingMessage = {
 };
 
 // @public (undocumented)
+export const mutedNoteReasons: readonly ["word", "manual", "spam", "other"];
+
+// @public (undocumented)
 type Note = {
     id: ID;
     createdAt: DateString;
@@ -2192,8 +2198,12 @@ type Note = {
     files: DriveFile[];
     fileIds: DriveFile['id'][];
     visibility: 'public' | 'home' | 'followers' | 'specified';
+    visibleUserIds?: User['id'][];
+    localOnly?: boolean;
     myReaction?: string;
     reactions: Record<string, number>;
+    renoteCount: number;
+    repliesCount: number;
     poll?: {
         expiresAt: DateString | null;
         multiple: boolean;
@@ -2207,6 +2217,9 @@ type Note = {
         name: string;
         url: string;
     }[];
+    uri?: string;
+    url?: string;
+    isHidden?: boolean;
 };
 
 // @public (undocumented)
@@ -2224,6 +2237,9 @@ type NoteReaction = {
     user: UserLite;
     type: string;
 };
+
+// @public (undocumented)
+export const noteVisibilities: readonly ["public", "home", "followers", "specified"];
 
 // @public (undocumented)
 type Notification_2 = {
@@ -2286,6 +2302,9 @@ type Notification_2 = {
 });
 
 // @public (undocumented)
+export const notificationTypes: readonly ["follow", "mention", "reply", "renote", "quote", "reaction", "pollVote", "receiveFollowRequest", "followRequestAccepted", "groupInvited", "app"];
+
+// @public (undocumented)
 type OriginType = 'combined' | 'local' | 'remote';
 
 // @public (undocumented)
@@ -2319,6 +2338,9 @@ type PageEvent = {
     userId: User['id'];
     user: User;
 };
+
+// @public (undocumented)
+export const permissions: string[];
 
 // @public (undocumented)
 type ServerInfo = {
@@ -2423,6 +2445,14 @@ type UserLite = {
         name: string;
         url: string;
     }[];
+    instance?: {
+        name: Instance['name'];
+        softwareName: Instance['softwareName'];
+        softwareVersion: Instance['softwareVersion'];
+        iconUrl: Instance['iconUrl'];
+        faviconUrl: Instance['faviconUrl'];
+        themeColor: Instance['themeColor'];
+    };
 };
 
 // @public (undocumented)

--- a/etc/misskey-js.api.md
+++ b/etc/misskey-js.api.md
@@ -2047,9 +2047,6 @@ type FetchLike = (input: string, init?: {
 }>;
 
 // @public (undocumented)
-export const ffVisibility: readonly ["public", "followers", "private"];
-
-// @public (undocumented)
 type Following = {
     id: ID;
     createdAt: DateString;
@@ -2181,9 +2178,6 @@ type MessagingMessage = {
 };
 
 // @public (undocumented)
-export const mutedNoteReasons: readonly ["word", "manual", "spam", "other"];
-
-// @public (undocumented)
 type Note = {
     id: ID;
     createdAt: DateString;
@@ -2198,12 +2192,8 @@ type Note = {
     files: DriveFile[];
     fileIds: DriveFile['id'][];
     visibility: 'public' | 'home' | 'followers' | 'specified';
-    visibleUserIds?: User['id'][];
-    localOnly?: boolean;
     myReaction?: string;
     reactions: Record<string, number>;
-    renoteCount: number;
-    repliesCount: number;
     poll?: {
         expiresAt: DateString | null;
         multiple: boolean;
@@ -2217,9 +2207,6 @@ type Note = {
         name: string;
         url: string;
     }[];
-    uri?: string;
-    url?: string;
-    isHidden?: boolean;
 };
 
 // @public (undocumented)
@@ -2237,9 +2224,6 @@ type NoteReaction = {
     user: UserLite;
     type: string;
 };
-
-// @public (undocumented)
-export const noteVisibilities: readonly ["public", "home", "followers", "specified"];
 
 // @public (undocumented)
 type Notification_2 = {
@@ -2302,9 +2286,6 @@ type Notification_2 = {
 });
 
 // @public (undocumented)
-export const notificationTypes: readonly ["follow", "mention", "reply", "renote", "quote", "reaction", "pollVote", "receiveFollowRequest", "followRequestAccepted", "groupInvited", "app"];
-
-// @public (undocumented)
 type OriginType = 'combined' | 'local' | 'remote';
 
 // @public (undocumented)
@@ -2338,9 +2319,6 @@ type PageEvent = {
     userId: User['id'];
     user: User;
 };
-
-// @public (undocumented)
-export const permissions: string[];
 
 // @public (undocumented)
 type ServerInfo = {
@@ -2445,14 +2423,6 @@ type UserLite = {
         name: string;
         url: string;
     }[];
-    instance?: {
-        name: Instance['name'];
-        softwareName: Instance['softwareName'];
-        softwareVersion: Instance['softwareVersion'];
-        iconUrl: Instance['iconUrl'];
-        faviconUrl: Instance['faviconUrl'];
-        themeColor: Instance['themeColor'];
-    };
 };
 
 // @public (undocumented)

--- a/src/streaming.types.ts
+++ b/src/streaming.types.ts
@@ -1,4 +1,4 @@
-import { CustomEmoji, DriveFile, MeDetailed, MessagingMessage, Note, Notification, PageEvent, User, UserGroup } from './entities';
+import { Antenna, CustomEmoji, DriveFile, MeDetailed, MessagingMessage, Note, Notification, PageEvent, User, UserGroup } from './entities';
 
 type FIXME = any;
 
@@ -16,21 +16,31 @@ export type Channels = {
 			meUpdated: (payload: MeDetailed) => void;
 			pageEvent: (payload: PageEvent) => void;
 			urlUploadFinished: (payload: { marker: string; file: DriveFile; }) => void;
-			messagingMessage: (payload: MessagingMessage) => void;
 			readAllNotifications: () => void;
-			unreadNotification: () => void;
-			unreadMention: () => void;
+			unreadNotification: (payload: Notification) => void;
+			unreadMention: (payload: Note['id']) => void;
 			readAllUnreadMentions: () => void;
-			unreadSpecifiedNote: () => void;
+			unreadSpecifiedNote: (payload: Note['id']) => void;
 			readAllUnreadSpecifiedNotes: () => void;
 			readAllMessagingMessages: () => void;
-			unreadMessagingMessage: () => void;
+			messagingMessage: (payload: MessagingMessage) => void;
+			unreadMessagingMessage: (payload: MessagingMessage) => void;
 			readAllAntennas: () => void;
-			unreadAntenna: () => void;
+			unreadAntenna: (payload: Antenna) => void;
 			readAllAnnouncements: () => void;
 			readAllChannels: () => void;
-			unreadChannel: () => void;
+			unreadChannel: (payload: Note['id']) => void;
 			myTokenRegenerated: () => void;
+			reversiNoInvites: () => void;
+			reversiInvited: (payload: FIXME) => void;
+			signin: (payload: FIXME) => void;
+			registryUpdated: (payload: {
+				scope?: string[];
+				key: string;
+				value: any | null;
+			}) => void;
+			driveFileCreated: (paload: 'DriveFile') => void;
+			readAntenna: (payload: Antenna) => void;
 		};
 		receives: null;
 	};

--- a/src/streaming.types.ts
+++ b/src/streaming.types.ts
@@ -39,7 +39,7 @@ export type Channels = {
 				key: string;
 				value: any | null;
 			}) => void;
-			driveFileCreated: (paload: 'DriveFile') => void;
+			driveFileCreated: (payload: DriveFile) => void;
 			readAntenna: (payload: Antenna) => void;
 		};
 		receives: null;


### PR DESCRIPTION
Fix #35

# What
[本体の定義](https://github.com/misskey-dev/misskey/blob/12.100.2/packages/backend/src/server/api/stream/types.ts#L45)をもとにメインストリームの定義を追加します
