### PR TITLE
fix: Add comment property to DriveFile

### DIFF
--- a/src/entities.ts
+++ b/src/entities.ts
@@ -117,6 +117,7 @@ export type DriveFile = {
 	size: number;
 	md5: string;
 	blurhash: string;
+	comment: string;
 	properties: Record<string, any>;
 };
 

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -117,7 +117,7 @@ export type DriveFile = {
 	size: number;
 	md5: string;
 	blurhash: string;
-	comment: string;
+	comment: string | null;
 	properties: Record<string, any>;
 };
 


### PR DESCRIPTION
# What
Adds the `comment` property to DriveFile.

# Why
Some components of Misskey like the image viewer use this property, but it hasn't been defined in the type definition itself.
