### PR TITLE
Fix: application/json の content-type header をデフォルトで付与する

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -19,6 +19,7 @@ export type FetchLike = (input: string, init?: {
 		body?: string;
 		credentials?: RequestCredentials;
 		cache?: RequestCache;
+		headers: {[key in string]: string}
 	}) => Promise<{
 		status: number;
 		json(): Promise<any>;
@@ -75,6 +76,9 @@ export class APIClient {
 					...params,
 					i: credential !== undefined ? credential : this.credential,
 				}),
+				headers: {
+					'Content-Type': 'application/json',
+				},
 				credentials: 'omit',
 				cache: 'no-cache',
 			}).then(async (res) => {


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
application/json の content-type header をデフォルトで付与する

# Why

<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Request Headerが指定されていない。 content-type: text/plain; utf-8 が採用される

そうすると、v13でcontent-typeを厳密チェックするようになったためリクエストが失敗する

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
