### PR TITLE
await res.json() がコケることがあるのでtry catchする

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -82,16 +82,22 @@ export class APIClient {
 				credentials: 'omit',
 				cache: 'no-cache',
 			}).then(async (res) => {
-				const body = res.status === 204 ? null : await res.json();
-	
-				if (res.status === 200) {
-					resolve(body);
-				} else if (res.status === 204) {
-					resolve(null);
-				} else {
+				try {
+					const body = res.status === 204 ? null : await res.json();
+
+					if (res.status === 200) {
+						resolve(body);
+					} else if (res.status === 204) {
+						resolve(null);
+					} else {
+						reject({
+							[MK_API_ERROR]: true,
+							...body.error,
+						});
+					}
+				} catch (e) {
 					reject({
-						[MK_API_ERROR]: true,
-						...body.error,
+						message: e,
 					});
 				}
 			}).catch(reject);


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey.js/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey.js/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
misskey.js の client が request するとき、 jsonが帰ってくることを期待せず、jsonでなければなんか適当にメッセージをrejectする


# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->


misskey.js の client が request するとき、CDNなどの都合でHTMLなどが帰ってくることがある。
この場合、Promise が reject となるわけではないので、 then節へ突入する。status code は200とか204だったりする。
すると .json() したときに JSON.parse() すると例外を発生させるが、これは実行時例外となりどこにもcatchされない
Unexpected token "<" って出てるヤツがこれ

requestの中で発生しているため使う側でtry catch してもでてくるのでなんかしら対処は必要な認識

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
